### PR TITLE
[Backport] issue fixed #20299 Order item details label not aligned in mobile view

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_cart.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_cart.less
@@ -501,6 +501,17 @@
             }
         }
     }
+    
+    .cart.table-wrapper,
+    .order-items.table-wrapper {
+        .col.price,
+        .col.qty,
+        .col.subtotal,
+        .col.msrp {
+            text-align: left;
+        }
+    }
+    
 }
 
 //

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_cart.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_cart.less
@@ -501,7 +501,7 @@
             }
         }
     }
-    
+
     .cart.table-wrapper,
     .order-items.table-wrapper {
         .col.price,
@@ -511,7 +511,7 @@
             text-align: left;
         }
     }
-    
+
 }
 
 //


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/20301
issue fixed #20299 Order item details label not aligned in mobile view


### Manual testing scenarios (*)

Step 1: Open frontend and login as customer
Step 2: Go to my account section
Step 3: Click on My order link and open detail any order in mobile
Step 4: You will issue as shown in screenshot

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
