### PR TITLE
[Backport] Added option to exclude discount for minimum order amount calculation

### DIFF
--- a/app/code/Magento/Quote/Model/Quote.php
+++ b/app/code/Magento/Quote/Model/Quote.php
@@ -2256,11 +2256,10 @@ class Quote extends AbstractExtensibleModel implements \Magento\Quote\Api\Data\C
                 $taxes = ($taxInclude) ? $address->getBaseTaxAmount() : 0;
                 foreach ($address->getQuote()->getItemsCollection() as $item) {
                     /** @var \Magento\Quote\Model\Quote\Item $item */
-                    if ($includeDiscount) {
-                        $amount = $item->getBaseRowTotal() - $item->getBaseDiscountAmount() + $taxes;
-                    } else {
-                        $amount = $taxInclude ? $item->getBaseRowTotalInclTax() : $item->getBaseRowTotal();
-                    }
+                    $amount = $includeDiscount ?
+                        $item->getBaseRowTotal() - $item->getBaseDiscountAmount() + $taxes :
+                        $item->getBaseRowTotal() + $taxes;
+
                     if ($amount < $minAmount) {
                         return false;
                     }
@@ -2270,11 +2269,9 @@ class Quote extends AbstractExtensibleModel implements \Magento\Quote\Api\Data\C
             $baseTotal = 0;
             foreach ($addresses as $address) {
                 $taxes = ($taxInclude) ? $address->getBaseTaxAmount() : 0;
-                if ($includeDiscount) {
-                    $baseTotal += $address->getBaseSubtotalWithDiscount() + $taxes;
-                } else {
-                    $baseTotal += $taxInclude ? $address->getBaseSubtotalTotalInclTax() : $address->getBaseSubtotal();
-                }
+                $baseTotal += $includeDiscount ?
+                    $address->getBaseSubtotalWithDiscount() + $taxes :
+                    $address->getBaseSubtotal() + $taxes;
             }
             if ($baseTotal < $minAmount) {
                 return false;

--- a/app/code/Magento/Quote/Model/Quote/Address.php
+++ b/app/code/Magento/Quote/Model/Quote/Address.php
@@ -1166,17 +1166,11 @@ class Address extends \Magento\Customer\Model\Address\AbstractAddress implements
             $storeId
         );
 
-        if ($includeDiscount) {
-            $taxes = $taxInclude ? $this->getBaseTaxAmount() : 0;
+        $taxes = $taxInclude ? $this->getBaseTaxAmount() : 0;
 
-            $isMinimumReached = ($this->getBaseSubtotalWithDiscount() + $taxes >= $amount);
-        } else {
-            $isMinimumReached = $taxInclude
-                ? ($this->getBaseSubtotalTotalInclTax() >= $amount)
-                : ($this->getBaseSubtotal() >= $amount);
-        }
-
-        return $isMinimumReached;
+        return $includeDiscount ?
+            ($this->getBaseSubtotalWithDiscount() + $taxes >= $amount) :
+            ($this->getBaseSubtotal() + $taxes >= $amount);
     }
 
     /**

--- a/app/code/Magento/Quote/Model/Quote/Address.php
+++ b/app/code/Magento/Quote/Model/Quote/Address.php
@@ -1150,6 +1150,11 @@ class Address extends \Magento\Customer\Model\Address\AbstractAddress implements
             return true;
         }
 
+        $includeDiscount = $this->_scopeConfig->getValue(
+            'sales/minimum_order/include_discount_amount',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
         $amount = $this->_scopeConfig->getValue(
             'sales/minimum_order/amount',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
@@ -1160,9 +1165,18 @@ class Address extends \Magento\Customer\Model\Address\AbstractAddress implements
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
             $storeId
         );
-        $taxes = $taxInclude ? $this->getBaseTaxAmount() : 0;
 
-        return ($this->getBaseSubtotalWithDiscount() + $taxes >= $amount);
+        if ($includeDiscount) {
+            $taxes = $taxInclude ? $this->getBaseTaxAmount() : 0;
+
+            $isMinimumReached = ($this->getBaseSubtotalWithDiscount() + $taxes >= $amount);
+        } else {
+            $isMinimumReached = $taxInclude
+                ? ($this->getBaseSubtotalTotalInclTax() >= $amount)
+                : ($this->getBaseSubtotal() >= $amount);
+        }
+
+        return $isMinimumReached;
     }
 
     /**

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/AddressTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/AddressTest.php
@@ -216,6 +216,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
         $scopeConfigValues = [
             ['sales/minimum_order/active', ScopeInterface::SCOPE_STORE, $storeId, true],
             ['sales/minimum_order/amount', ScopeInterface::SCOPE_STORE, $storeId, 20],
+            ['sales/minimum_order/include_discount_amount', ScopeInterface::SCOPE_STORE, $storeId, true],
             ['sales/minimum_order/tax_including', ScopeInterface::SCOPE_STORE, $storeId, true],
         ];
 
@@ -240,6 +241,31 @@ class AddressTest extends \PHPUnit\Framework\TestCase
         $scopeConfigValues = [
             ['sales/minimum_order/active', ScopeInterface::SCOPE_STORE, $storeId, true],
             ['sales/minimum_order/amount', ScopeInterface::SCOPE_STORE, $storeId, 20],
+            ['sales/minimum_order/include_discount_amount', ScopeInterface::SCOPE_STORE, $storeId, true],
+            ['sales/minimum_order/tax_including', ScopeInterface::SCOPE_STORE, $storeId, true],
+        ];
+
+        $this->quote->expects($this->once())
+            ->method('getStoreId')
+            ->willReturn($storeId);
+        $this->quote->expects($this->once())
+            ->method('getIsVirtual')
+            ->willReturn(false);
+
+        $this->scopeConfig->expects($this->once())
+            ->method('isSetFlag')
+            ->willReturnMap($scopeConfigValues);
+
+        $this->assertTrue($this->address->validateMinimumAmount());
+    }
+
+    public function testValidateMiniumumAmountWithoutDiscount()
+    {
+        $storeId = 1;
+        $scopeConfigValues = [
+            ['sales/minimum_order/active', ScopeInterface::SCOPE_STORE, $storeId, true],
+            ['sales/minimum_order/amount', ScopeInterface::SCOPE_STORE, $storeId, 20],
+            ['sales/minimum_order/include_discount_amount', ScopeInterface::SCOPE_STORE, $storeId, false],
             ['sales/minimum_order/tax_including', ScopeInterface::SCOPE_STORE, $storeId, true],
         ];
 
@@ -263,6 +289,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
         $scopeConfigValues = [
             ['sales/minimum_order/active', ScopeInterface::SCOPE_STORE, $storeId, true],
             ['sales/minimum_order/amount', ScopeInterface::SCOPE_STORE, $storeId, 20],
+            ['sales/minimum_order/include_discount_amount', ScopeInterface::SCOPE_STORE, $storeId, true],
             ['sales/minimum_order/tax_including', ScopeInterface::SCOPE_STORE, $storeId, true],
         ];
 

--- a/app/code/Magento/Quote/Test/Unit/Model/QuoteTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/QuoteTest.php
@@ -951,6 +951,7 @@ class QuoteTest extends \PHPUnit\Framework\TestCase
             ['sales/minimum_order/active', ScopeInterface::SCOPE_STORE, $storeId, true],
             ['sales/minimum_order/multi_address', ScopeInterface::SCOPE_STORE, $storeId, true],
             ['sales/minimum_order/amount', ScopeInterface::SCOPE_STORE, $storeId, 20],
+            ['sales/minimum_order/include_discount_amount', ScopeInterface::SCOPE_STORE, $storeId, true],
             ['sales/minimum_order/tax_including', ScopeInterface::SCOPE_STORE, $storeId, true],
         ];
         $this->scopeConfig->expects($this->any())
@@ -977,6 +978,7 @@ class QuoteTest extends \PHPUnit\Framework\TestCase
             ['sales/minimum_order/active', ScopeInterface::SCOPE_STORE, $storeId, true],
             ['sales/minimum_order/multi_address', ScopeInterface::SCOPE_STORE, $storeId, true],
             ['sales/minimum_order/amount', ScopeInterface::SCOPE_STORE, $storeId, 20],
+            ['sales/minimum_order/include_discount_amount', ScopeInterface::SCOPE_STORE, $storeId, true],
             ['sales/minimum_order/tax_including', ScopeInterface::SCOPE_STORE, $storeId, true],
         ];
         $this->scopeConfig->expects($this->any())

--- a/app/code/Magento/Sales/etc/adminhtml/system.xml
+++ b/app/code/Magento/Sales/etc/adminhtml/system.xml
@@ -89,6 +89,11 @@
                     <label>Minimum Amount</label>
                     <comment>Subtotal after discount</comment>
                 </field>
+                <field id="include_discount_amount" translate="label" sortOrder="12" type="select" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+                    <label>Include Discount Amount</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>Choosing yes will be used subtotal after discount, otherwise only subtotal will be used</comment>
+                </field>
                 <field id="tax_including" translate="label" sortOrder="15" type="select" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Include Tax to Amount</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/app/code/Magento/Sales/etc/config.xml
+++ b/app/code/Magento/Sales/etc/config.xml
@@ -22,6 +22,7 @@
                 <allow_zero_grandtotal>1</allow_zero_grandtotal>
             </zerograndtotal_creditmemo>
             <minimum_order>
+                <include_discount_amount>1</include_discount_amount>
                 <tax_including>1</tax_including>
             </minimum_order>
             <orders>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19136
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR adds option for store manager to include or exclude discount amount from minimum order amount calculation. Sometimes client wants to exclude discount amount from minimum order and want that only subtotal is used. The default option is set to "Yes" so Magento will use the current behavior.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
none

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Access backend
2. Go to Stores > Configuration > Sales > Sales > Minimum Order Amount
3. Leave "Yes" in "Include Discount Amount" field to test normal behaviour.
4. Set "No" in "Include Discount Amount" field to test new behaviour without discount.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
