### PR TITLE
[Backport] Tier price on configurable product sorting sometimes wrong

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection.php
@@ -2205,7 +2205,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
             $this->getLinkField() . ' IN(?)',
             $productIds
         )->order(
-            $this->getLinkField()
+            'qty'
         );
         return $select;
     }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/20407
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Tier prices on configurable product have sorting that differ then in back office.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
- magento/magento2#12194: Tier price on configurable product sorting sometimes wrong


### Manual testing scenarios (*)
1. edit option assigned to configurable product
2. add tier prices to option: 
 - all websites ; all groups ; qty 4; price 1
 - all websites ; all groups ; qty 3; price 2
 - all websites ; all groups ; qty 2; price 3
3. save option
4. visit configurable product detail page
Tier Prices on frontend should be in displayed in same order as in back office

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
