### PR TITLE
[Backport] magento/magento2#?: Mark not used downloadable blocks, tests, layout updates and templates as deprecated.

### DIFF
--- a/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Downloadable.php
+++ b/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Downloadable.php
@@ -14,6 +14,8 @@ namespace Magento\Downloadable\Block\Adminhtml\Catalog\Product\Composite\Fieldse
 /**
  * @api
  * @since 100.0.2
+ * @deprecated
+ * @see \Magento\Downloadable\Ui\DataProvider\Product\Form\Modifier\Composite
  */
 class Downloadable extends \Magento\Downloadable\Block\Catalog\Product\Links
 {

--- a/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable.php
+++ b/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable.php
@@ -15,6 +15,8 @@ use Magento\Framework\Registry;
  * Adminhtml catalog product downloadable items tab and form
  *
  * @author      Magento Core Team <core@magentocommerce.com>
+ * @deprecated
+ * @see \Magento\Downloadable\Ui\DataProvider\Product\Form\Modifier\Composite
  */
 class Downloadable extends Widget implements TabInterface
 {

--- a/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
+++ b/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
@@ -10,6 +10,9 @@ namespace Magento\Downloadable\Block\Adminhtml\Catalog\Product\Edit\Tab\Download
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ *
+ * @deprecated
+ * @see \Magento\Downloadable\Ui\DataProvider\Product\Form\Modifier\Links
  */
 class Links extends \Magento\Backend\Block\Template
 {

--- a/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
+++ b/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
@@ -9,6 +9,9 @@ namespace Magento\Downloadable\Block\Adminhtml\Catalog\Product\Edit\Tab\Download
  * Adminhtml catalog product downloadable items tab links section
  *
  * @author      Magento Core Team <core@magentocommerce.com>
+ *
+ * @deprecated
+ * @see \Magento\Downloadable\Ui\DataProvider\Product\Form\Modifier\Samples
  */
 class Samples extends \Magento\Backend\Block\Widget
 {

--- a/app/code/Magento/Downloadable/Controller/Adminhtml/Downloadable/Product/Edit/Form.php
+++ b/app/code/Magento/Downloadable/Controller/Adminhtml/Downloadable/Product/Edit/Form.php
@@ -6,6 +6,13 @@
  */
 namespace Magento\Downloadable\Controller\Adminhtml\Downloadable\Product\Edit;
 
+/**
+ * Class Form
+ *
+ * @deprecated since downloadable information rendering moved to UI components.
+ * @see \Magento\Downloadable\Ui\DataProvider\Product\Form\Modifier\Composite
+ * @package Magento\Downloadable\Controller\Adminhtml\Downloadable\Product\Edit
+ */
 class Form extends \Magento\Catalog\Controller\Adminhtml\Product\Edit
 {
     /**

--- a/app/code/Magento/Downloadable/Test/Unit/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/LinksTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/LinksTest.php
@@ -5,6 +5,14 @@
  */
 namespace Magento\Downloadable\Test\Unit\Block\Adminhtml\Catalog\Product\Edit\Tab\Downloadable;
 
+/**
+ * Class LinksTest
+ *
+ * @package Magento\Downloadable\Test\Unit\Block\Adminhtml\Catalog\Product\Edit\Tab\Downloadable
+ *
+ * @deprecated
+ * @see \Magento\Downloadable\Ui\DataProvider\Product\Form\Modifier\Links
+ */
 class LinksTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/code/Magento/Downloadable/Test/Unit/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/SamplesTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/SamplesTest.php
@@ -5,6 +5,14 @@
  */
 namespace Magento\Downloadable\Test\Unit\Block\Adminhtml\Catalog\Product\Edit\Tab\Downloadable;
 
+/**
+ * Class SamplesTest
+ *
+ * @package Magento\Downloadable\Test\Unit\Block\Adminhtml\Catalog\Product\Edit\Tab\Downloadable
+ *
+ * @deprecated
+ * @see \Magento\Downloadable\Ui\DataProvider\Product\Form\Modifier\Samples
+ */
 class SamplesTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/code/Magento/Downloadable/view/adminhtml/layout/catalog_product_downloadable.xml
+++ b/app/code/Magento/Downloadable/view/adminhtml/layout/catalog_product_downloadable.xml
@@ -5,6 +5,10 @@
  * See COPYING.txt for license details.
  */
 -->
+<!--
+@deprecated Adminhtml Blocks extending for Downloadable products have neen moved to UI components
+@see \Magento\Downloadable\Ui\DataProvider\Product\Form\Modifier\Composite
+-->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <update handle="downloadable_items"/>
     <body>

--- a/app/code/Magento/Downloadable/view/adminhtml/layout/catalog_product_simple.xml
+++ b/app/code/Magento/Downloadable/view/adminhtml/layout/catalog_product_simple.xml
@@ -5,6 +5,10 @@
  * See COPYING.txt for license details.
  */
 -->
+<!--
+@deprecated Adminhtml Blocks extending for Downloadable products have neen moved to UI components
+@see \Magento\Downloadable\Ui\DataProvider\Product\Form\Modifier\Composite
+-->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <update handle="downloadable_items"/>
 </page>

--- a/app/code/Magento/Downloadable/view/adminhtml/layout/catalog_product_view_type_downloadable.xml
+++ b/app/code/Magento/Downloadable/view/adminhtml/layout/catalog_product_view_type_downloadable.xml
@@ -5,6 +5,10 @@
  * See COPYING.txt for license details.
  */
 -->
+<!--
+@deprecated Adminhtml Blocks extending for Downloadable products have neen moved to UI components
+@see \Magento\Downloadable\Ui\DataProvider\Product\Form\Modifier\Composite
+-->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="product.composite.fieldset">

--- a/app/code/Magento/Downloadable/view/adminhtml/layout/catalog_product_virtual.xml
+++ b/app/code/Magento/Downloadable/view/adminhtml/layout/catalog_product_virtual.xml
@@ -5,6 +5,10 @@
  * See COPYING.txt for license details.
  */
 -->
+<!--
+@deprecated Adminhtml Blocks extending for Downloadable products have neen moved to UI components
+@see \Magento\Downloadable\Ui\DataProvider\Product\Form\Modifier\Composite
+-->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <update handle="downloadable_items"/>
 </page>

--- a/app/code/Magento/Downloadable/view/adminhtml/layout/downloadable_items.xml
+++ b/app/code/Magento/Downloadable/view/adminhtml/layout/downloadable_items.xml
@@ -5,6 +5,10 @@
  * See COPYING.txt for license details.
  */
 -->
+<!--
+@deprecated Adminhtml Blocks extending for Downloadable products have neen moved to UI components
+@see \Magento\Downloadable\Ui\DataProvider\Product\Form\Modifier\Composite
+-->
 <layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_layout.xsd">
     <!--<referenceContainer name="product_form">-->
         <!--<block name="downloadable_items" class="Magento\Downloadable\Block\Adminhtml\Catalog\Product\Edit\Tab\Downloadable">-->

--- a/app/code/Magento/Downloadable/view/adminhtml/templates/product/composite/fieldset/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/templates/product/composite/fieldset/downloadable.phtml
@@ -4,6 +4,7 @@
  * See COPYING.txt for license details.
  */
 
+// @deprecated
 // @codingStandardsIgnoreFile
 
 ?>

--- a/app/code/Magento/Downloadable/view/adminhtml/templates/product/edit/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/templates/product/edit/downloadable.phtml
@@ -4,6 +4,7 @@
  * See COPYING.txt for license details.
  */
 
+// @deprecated
 // @codingStandardsIgnoreFile
 
 ?>

--- a/app/code/Magento/Downloadable/view/adminhtml/templates/product/edit/downloadable/links.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/templates/product/edit/downloadable/links.phtml
@@ -4,6 +4,7 @@
  * See COPYING.txt for license details.
  */
 
+// @deprecated
 // @codingStandardsIgnoreFile
 
 ?>

--- a/app/code/Magento/Downloadable/view/adminhtml/templates/product/edit/downloadable/samples.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/templates/product/edit/downloadable/samples.phtml
@@ -4,6 +4,7 @@
  * See COPYING.txt for license details.
  */
 
+// @deprecated
 // @codingStandardsIgnoreFile
 
 ?>

--- a/dev/tests/integration/testsuite/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/LinksTest.php
+++ b/dev/tests/integration/testsuite/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/LinksTest.php
@@ -5,6 +5,13 @@
  */
 namespace Magento\Downloadable\Block\Adminhtml\Catalog\Product\Edit\Tab\Downloadable;
 
+/**
+ * Class LinksTest
+ *
+ * @package Magento\Downloadable\Block\Adminhtml\Catalog\Product\Edit\Tab\Downloadable
+ * @deprecated
+ * @see \Magento\Downloadable\Ui\DataProvider\Product\Form\Modifier\Links
+ */
 class LinksTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/dev/tests/integration/testsuite/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/SamplesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/SamplesTest.php
@@ -5,6 +5,13 @@
  */
 namespace Magento\Downloadable\Block\Adminhtml\Catalog\Product\Edit\Tab\Downloadable;
 
+/**
+ * Class SamplesTest
+ *
+ * @package Magento\Downloadable\Block\Adminhtml\Catalog\Product\Edit\Tab\Downloadable
+ * @deprecated
+ * @see \Magento\Downloadable\Ui\DataProvider\Product\Form\Modifier\Samples
+ */
 class SamplesTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetUploadButtonsHtml()


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19822
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Investigated and mark as deprecated blocks, layout updates, templates.
Mark as deprecated corresponding unit and integration tests. 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. No corresponding issue.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Crash or delete any file from pull request (brake xml or php code).
2. Visit Product Edit Page in Admin panel.
#### Expected result
1. Page crashed or downloadable setting tab is missing.
#### Actual result
1. Changes have no effect.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
