### PR TITLE
[Backport] Avoid duplicate loading of configuration files

### DIFF
--- a/app/code/Magento/Catalog/Model/Category/Attribute/Source/Layout.php
+++ b/app/code/Magento/Catalog/Model/Category/Attribute/Source/Layout.php
@@ -18,6 +18,12 @@ class Layout extends \Magento\Eav\Model\Entity\Attribute\Source\AbstractSource
     protected $pageLayoutBuilder;
 
     /**
+     * @inheritdoc
+     * @deprecated since the cache is now handled by \Magento\Theme\Model\PageLayout\Config\Builder::$configFiles
+     */
+    protected $_options = null;
+
+    /**
      * @param \Magento\Framework\View\Model\PageLayout\Config\BuilderInterface $pageLayoutBuilder
      */
     public function __construct(\Magento\Framework\View\Model\PageLayout\Config\BuilderInterface $pageLayoutBuilder)
@@ -26,14 +32,14 @@ class Layout extends \Magento\Eav\Model\Entity\Attribute\Source\AbstractSource
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getAllOptions()
     {
-        if (!$this->_options) {
-            $this->_options = $this->pageLayoutBuilder->getPageLayoutsConfig()->toOptionArray();
-            array_unshift($this->_options, ['value' => '', 'label' => __('No layout updates')]);
-        }
-        return $this->_options;
+        $options = $this->pageLayoutBuilder->getPageLayoutsConfig()->toOptionArray();
+        array_unshift($options, ['value' => '', 'label' => __('No layout updates')]);
+        $this->_options = $options;
+
+        return $options;
     }
 }

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Source/Layout.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Source/Layout.php
@@ -18,6 +18,12 @@ class Layout extends \Magento\Eav\Model\Entity\Attribute\Source\AbstractSource
     protected $pageLayoutBuilder;
 
     /**
+     * @inheritdoc
+     * @deprecated since the cache is now handled by \Magento\Theme\Model\PageLayout\Config\Builder::$configFiles
+     */
+    protected $_options = null;
+
+    /**
      * @param \Magento\Framework\View\Model\PageLayout\Config\BuilderInterface $pageLayoutBuilder
      */
     public function __construct(\Magento\Framework\View\Model\PageLayout\Config\BuilderInterface $pageLayoutBuilder)
@@ -26,14 +32,14 @@ class Layout extends \Magento\Eav\Model\Entity\Attribute\Source\AbstractSource
     }
 
     /**
-     * @return array
+     * @inheritdoc
      */
     public function getAllOptions()
     {
-        if (!$this->_options) {
-            $this->_options = $this->pageLayoutBuilder->getPageLayoutsConfig()->toOptionArray();
-            array_unshift($this->_options, ['value' => '', 'label' => __('No layout updates')]);
-        }
-        return $this->_options;
+        $options = $this->pageLayoutBuilder->getPageLayoutsConfig()->toOptionArray();
+        array_unshift($options, ['value' => '', 'label' => __('No layout updates')]);
+        $this->_options = $options;
+
+        return $options;
     }
 }

--- a/app/code/Magento/Cms/Model/Page/Source/PageLayout.php
+++ b/app/code/Magento/Cms/Model/Page/Source/PageLayout.php
@@ -20,6 +20,7 @@ class PageLayout implements OptionSourceInterface
 
     /**
      * @var array
+     * @deprecated since the cache is now handled by \Magento\Theme\Model\PageLayout\Config\Builder::$configFiles
      */
     protected $options;
 
@@ -34,16 +35,10 @@ class PageLayout implements OptionSourceInterface
     }
 
     /**
-     * Get options
-     *
-     * @return array
+     * @inheritdoc
      */
     public function toOptionArray()
     {
-        if ($this->options !== null) {
-            return $this->options;
-        }
-
         $configOptions = $this->pageLayoutBuilder->getPageLayoutsConfig()->getOptions();
         $options = [];
         foreach ($configOptions as $key => $value) {
@@ -54,6 +49,6 @@ class PageLayout implements OptionSourceInterface
         }
         $this->options = $options;
 
-        return $this->options;
+        return $options;
     }
 }

--- a/app/code/Magento/Theme/Model/PageLayout/Config/Builder.php
+++ b/app/code/Magento/Theme/Model/PageLayout/Config/Builder.php
@@ -49,7 +49,7 @@ class Builder implements \Magento\Framework\View\Model\PageLayout\Config\Builder
     }
 
     /**
-     * @return \Magento\Framework\View\PageLayout\Config
+     * @inheritdoc
      */
     public function getPageLayoutsConfig()
     {
@@ -61,7 +61,7 @@ class Builder implements \Magento\Framework\View\Model\PageLayout\Config\Builder
      */
     protected function getConfigFiles()
     {
-        if (empty($this->configFiles)) {
+        if (!$this->configFiles) {
             $configFiles = [];
             foreach ($this->themeCollection->loadRegisteredThemes() as $theme) {
                 $configFiles[] = $this->fileCollector->getFilesContent($theme, 'layouts.xml');

--- a/app/code/Magento/Theme/Model/PageLayout/Config/Builder.php
+++ b/app/code/Magento/Theme/Model/PageLayout/Config/Builder.php
@@ -28,6 +28,11 @@ class Builder implements \Magento\Framework\View\Model\PageLayout\Config\Builder
     protected $themeCollection;
 
     /**
+     * @var array
+     */
+    private $configFiles = [];
+
+    /**
      * @param \Magento\Framework\View\PageLayout\ConfigFactory $configFactory
      * @param \Magento\Framework\View\PageLayout\File\Collector\Aggregated $fileCollector
      * @param \Magento\Theme\Model\ResourceModel\Theme\Collection $themeCollection
@@ -56,11 +61,14 @@ class Builder implements \Magento\Framework\View\Model\PageLayout\Config\Builder
      */
     protected function getConfigFiles()
     {
-        $configFiles = [];
-        foreach ($this->themeCollection->loadRegisteredThemes() as $theme) {
-            $configFiles = array_merge($configFiles, $this->fileCollector->getFilesContent($theme, 'layouts.xml'));
+        if (empty($this->configFiles)) {
+            $configFiles = [];
+            foreach ($this->themeCollection->loadRegisteredThemes() as $theme) {
+                $configFiles[] = $this->fileCollector->getFilesContent($theme, 'layouts.xml');
+            }
+            $this->configFiles = array_merge(...$configFiles);
         }
 
-        return $configFiles;
+        return $this->configFiles;
     }
 }

--- a/app/code/Magento/Theme/Model/PageLayout/Config/Builder.php
+++ b/app/code/Magento/Theme/Model/PageLayout/Config/Builder.php
@@ -57,6 +57,8 @@ class Builder implements \Magento\Framework\View\Model\PageLayout\Config\Builder
     }
 
     /**
+     * Retrieve configuration files.
+     *
      * @return array
      */
     protected function getConfigFiles()

--- a/app/code/Magento/Theme/Test/Unit/Model/PageLayout/Config/BuilderTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/PageLayout/Config/BuilderTest.php
@@ -83,7 +83,7 @@ class BuilderTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->themeCollection->expects($this->any())
+        $this->themeCollection->expects($this->once())
             ->method('loadRegisteredThemes')
             ->willReturn([$theme1, $theme2]);
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19585
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
While I was investigating why some pages in back-office are extremely slow on my local environment, I found out that we are currently loading multiple times all `layouts.xml` files in the `\Magento\Theme\Model\PageLayout\Config\Builder` class.

Through this change, I propose to only load them one time by adding a new property to store the result and reuse it for the next calls. There is no structural change and the **loading time is reduced by almost 40%** on my local environment, as you can see with the screenshots from Blackfire below.

**Previously:** 
![Blackfire screenshot](https://duaw26jehqd4r.cloudfront.net/items/040x3c2r3U3V2C1r2n2U/getConfigFiles-before.png)

**Now:**
![Blackfire screenshot](https://duaw26jehqd4r.cloudfront.net/items/0Z0N1l1f1U0R0c3s0g1j/%5B21ac1bc61b4fca85535fd1301ddd76d0%5D_getConfigFiles-after.png)

**Comparison:**
![Blackfire screenshot](https://duaw26jehqd4r.cloudfront.net/items/3I0H2Y0Y013V032k3u2P/%5Bb764c16e271860806c6def46f5b542cc%5D_getConfigFiles-comparison.png)



### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Log in to the back office.
2. Go to Content > Pages.
3. Look at the loading time... 😄 

Please note that I'm using Docker for Mac [with this environment](https://github.com/EmakinaFR/docker-magento2), and the application is in `developer` mode with all caches activated. The latest version is used for both Docker and Magento.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
