### PR TITLE
[Backport] fixed Negative order amount in dashboard - #18754

### DIFF
--- a/app/code/Magento/Reports/Model/ResourceModel/Order/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Order/Collection.php
@@ -3,7 +3,6 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
 namespace Magento\Reports\Model\ResourceModel\Order;
 
 use Magento\Framework\DB\Select;
@@ -81,7 +80,7 @@ class Collection extends \Magento\Sales\Model\ResourceModel\Order\Collection
      * @param \Magento\Framework\Stdlib\DateTime\TimezoneInterface $localeDate
      * @param \Magento\Sales\Model\Order\Config $orderConfig
      * @param \Magento\Sales\Model\ResourceModel\Report\OrderFactory $reportOrderFactory
-     * @param null $connection
+     * @param \Magento\Framework\DB\Adapter\AdapterInterface $connection
      * @param \Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)

--- a/app/code/Magento/Reports/Model/ResourceModel/Order/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Order/Collection.php
@@ -825,7 +825,7 @@ class Collection extends \Magento\Sales\Model\ResourceModel\Order\Collection
     ) {
         $template = ($storeId != 0)
             ? '(main_table.base_subtotal - %2$s - %1$s - ABS(main_table.base_discount_amount) - %3$s)'
-            : '((main_table.base_subtotal - %1$s - %2$s - ABS(main_table.base_discount_amount) - %3$s) '
+            : '((main_table.base_subtotal - %1$s - %2$s - ABS(main_table.base_discount_amount) + %3$s) '
                 . ' * main_table.base_to_global_rate)';
         return sprintf($template, $baseSubtotalRefunded, $baseSubtotalCanceled, $baseDiscountCanceled);
     }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19372
Fixed issue of Negative order amount in dashboard latest order when order is cancelled where coupon has been used #18754

### Description (*)

User place an order with a coupon code, for example 4.95 EUR off then user is going to Cancel the order. After canceling the order nagetive amout is shown at Admin's Dashboard. This pull request resolve this issue.

### Fixed Issues (if relevant)

1. magento/magento2#18754: Negative order amount in dashboard latest order when order is cancelled where coupon has been used


### Manual testing scenarios (*)

1. Place an order with coupon code and without coupon code
2. Cancel the order which is having coupon code
3. Check the Order amount at Admin Dashboard

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
